### PR TITLE
update umbrella header

### DIFF
--- a/SWRevealView/SWRevealView/SWRevealView.h
+++ b/SWRevealView/SWRevealView/SWRevealView.h
@@ -15,5 +15,4 @@ FOUNDATION_EXPORT double SWRevealViewVersionNumber;
 FOUNDATION_EXPORT const unsigned char SWRevealViewVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <SWRevealView/PublicHeader.h>
-#import "SWRevealViewController.h"
-
+#import "SWRevealViewController/SWRevealViewController.h"


### PR DESCRIPTION
Your umbrealla header raise warning about not proper import. It was deprecated for now, but will be removed in next version (at least apple say so...)